### PR TITLE
entrypoint.sh changes.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,8 @@
 #!/bin/sh
-COA_CONFIG="coa-config"
+COA_CONFIG="/coa-config"
 
-# For testing locally
-if [[ -z "${GITHUB_WORKSPACE}" ]]; then
-  COA_PATH=${COA_CONFIG}
-else
-  COA_PATH="${GITHUB_WORKSPACE}/${COA_CONFIG}"
-fi
+echo "Writing config file to: '${COA_CONFIG}'."
+echo $1 >> $COA_CONFIG
+#cat $COA_CONFIG
 
-echo "Writing config file to: '${COA_PATH}'."
-echo $1 >> $COA_PATH
-#cat COA_PATH
-
-coa --config COA_PATH $2
+coa --config $COA_CONFIG $2


### PR DESCRIPTION
`entrypoint.sh` now uses `/coa-config` as the path to the config file.